### PR TITLE
Ajacobs/external blob storage

### DIFF
--- a/base/frontend/sourcegraph-frontend.Deployment.yaml
+++ b/base/frontend/sourcegraph-frontend.Deployment.yaml
@@ -54,6 +54,20 @@ spec:
           value: require
         - name: CODEINTEL_PGUSER
           value: FROM_CHAMBER
+        # BEGIN EXTERNAL BLOB STORAGE CONFIGURATION
+        - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
+          value: S3
+        - name: PRECISE_CODE_INTEL_UPLOAD_BUCKET
+          value: sourcegraph-precise-code-intel-stage-usw2 # precise-code-intel-bucket from terracode-tooling/stage/us-west-2/sourcegraph/s3.tf
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
+          value: FROM_CHAMBER
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+          value: FROM_CHAMBER
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_REGION
+          value: us-west-2
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
+          value: https://s3.$(PRECISE_CODE_INTEL_UPLOAD_AWS_REGION).amazonaws.com
+        # END EXTERNAL BLOB STORAGE CONFIGURATION
         - name: SRC_GIT_SERVERS
           value: gitserver-0.gitserver:3178
         # POD_NAME is used by CACHE_DIR

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: 355207333203.dkr.ecr.us-west-2.amazonaws.com/sourcegraph-precise-code-intel-worker:3.28.0-ajacobs-sourcegraph-precise-code-intel-worker-image  # TODO: replace this with non-branched image
+        image: 355207333203.dkr.ecr.us-west-2.amazonaws.com/sourcegraph-precise-code-intel-worker:3.28.0 # image built in sourcegraph/images repo
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -29,6 +29,20 @@ spec:
       containers:
       - name: precise-code-intel-worker
         env:
+        # BEGIN EXTERNAL BLOB STORAGE CONFIGURATION
+        - name: PRECISE_CODE_INTEL_UPLOAD_BACKEND
+          value: S3
+        - name: PRECISE_CODE_INTEL_UPLOAD_BUCKET
+          value: sourcegraph-precise-code-intel-stage-usw2 # precise-code-intel-bucket from terracode-tooling/stage/us-west-2/sourcegraph/s3.tf
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ACCESS_KEY_ID
+          value: FROM_CHAMBER
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_SECRET_ACCESS_KEY
+          value: FROM_CHAMBER
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_REGION
+          value: us-west-2
+        - name: PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT
+          value: https://s3.$(PRECISE_CODE_INTEL_UPLOAD_AWS_REGION).amazonaws.com
+        # END EXTERNAL BLOB STORAGE CONFIGURATION
         - name: NUM_WORKERS
           value: '4'
         - name: POD_NAME

--- a/base/precise-code-intel/worker.Deployment.yaml
+++ b/base/precise-code-intel/worker.Deployment.yaml
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: index.docker.io/sourcegraph/precise-code-intel-worker:3.28.0@sha256:80f0ad97f81f63fca0cd062e6be7a15642f4bc187ea9280cb658dd32edd1016d
+        image: 355207333203.dkr.ecr.us-west-2.amazonaws.com/sourcegraph-precise-code-intel-worker:3.28.0-ajacobs-sourcegraph-precise-code-intel-worker-image  # TODO: replace this with non-branched image
         terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Configure the `stage` sourcegraph deployment to utilize external S3 blob storage.

See https://docs.sourcegraph.com/admin/external_services/object_storage for more details

### Checklist
- [x] Apply changes to stage cluster following https://segment.atlassian.net/wiki/spaces/INFRA/pages/1984299017/Sourcegraph+Migrate+Blob+Storage+to+S3+Runbook
- [x] Merge https://github.com/segmentio/images/pull/528 on successful migration
- [x] Update `precise-code-intel-worker` deployment to use final image